### PR TITLE
Fix token retrieval and session validation

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken';
 
 export async function GET(req: NextRequest) {
   const cookieStore = cookies();
-  const token = (await cookieStore).get('auth-token')?.value;
+  const token = cookieStore.get('auth-token')?.value;
 
   if (!token) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/discounts/route.ts
+++ b/src/app/api/discounts/route.ts
@@ -8,7 +8,7 @@ import { authOptions } from "@/lib/auth";
 const prisma = new PrismaClient();
 
 export async function GET(req: NextRequest) {
-  const session = await getServerSession({ req, ...authOptions });
+  const session = await getServerSession(authOptions);
   if (!session || !["restaurant", "business"].includes(session.user.userType)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -30,7 +30,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const session = await getServerSession({ req, ...authOptions });
+  const session = await getServerSession(authOptions);
   if (!session || !["restaurant", "business"].includes(session.user.userType)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }


### PR DESCRIPTION
## Summary
- correct cookie retrieval in `auth/me` endpoint
- fix `getServerSession` calls in discounts API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834139c0e88325b50eb90566754691