### PR TITLE
Fix prisma missing in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.12.0",
+        "prisma": "^6.12.0",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "bcrypt": "^6.0.0",
@@ -34,7 +35,6 @@
         "@typescript-eslint/parser": "^8.38.0",
         "eslint": "^9.31.0",
         "eslint-config-next": "15.3.5",
-        "prisma": "^6.12.0",
         "tailwindcss": "^4",
         "typescript": "^5.8.3"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.12.0",
+    "prisma": "^6.12.0",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "bcrypt": "^6.0.0",
@@ -36,7 +37,6 @@
     "@typescript-eslint/parser": "^8.38.0",
     "eslint": "^9.31.0",
     "eslint-config-next": "15.3.5",
-    "prisma": "^6.12.0",
     "tailwindcss": "^4",
     "typescript": "^5.8.3"
   }


### PR DESCRIPTION
## Summary
- install `prisma` in production dependencies

## Testing
- `npm run build` *(fails: `prisma` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834aafe0ac8325961bf6f558e16600