### PR TITLE
Add name field to registration

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -23,6 +23,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({
       id: (payload as any).id,
       email: (payload as any).email,
+      name: (payload as any).name,
       userType: (payload as any).userType,
     });
   } catch (err) {

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -8,9 +8,9 @@ const prisma = new PrismaClient();
 
 export async function POST(req: NextRequest) {
   try {
-    const { email, password, userType } = await req.json();
+    const { email, password, userType, name } = await req.json();
 
-    if (!email || !password || !userType) {
+    if (!email || !password || !userType || !name) {
       return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
     }
 
@@ -25,11 +25,12 @@ export async function POST(req: NextRequest) {
       data: {
         email,
         password: hashedPassword,
+        name,
         userType,
       },
     });
 
-    return NextResponse.json({ id: user.id, email: user.email, userType: user.userType });
+    return NextResponse.json({ id: user.id, email: user.email, name: user.name, userType: user.userType });
   } catch (err) {
     console.error('Signup error:', err);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
   const [showLoginFields, setShowLoginFields] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [registerForm, setRegisterForm] = useState<{email: string | undefined, password: string | undefined, userType: "influencer" | "restaurant" | undefined} | null>(null);
+  const [registerForm, setRegisterForm] = useState<{email: string | undefined, password: string | undefined, name: string | undefined, userType: "influencer" | "restaurant" | undefined} | null>(null);
 
   useEffect(() => {
     if (userType && showLoginFields === false) {
@@ -36,7 +36,7 @@ export default function Home() {
 };
 
   const handleSignUp = async () => {
-    if (!registerForm?.email || !registerForm.password || !registerForm.userType) {
+    if (!registerForm?.email || !registerForm.password || !registerForm.userType || !registerForm.name) {
       alert("Please fill in all fields.");
       return;
     }
@@ -44,6 +44,7 @@ export default function Home() {
     const mappedUserType = registerForm.userType === "restaurant" ? "business" : "influencer";
     const mappedEmail = registerForm.email.trim().toLowerCase();
     const mappedPassword = registerForm.password;
+    const mappedName = registerForm.name.trim();
     
     const res = await fetch("/api/auth/signup", {
       method: "POST",
@@ -53,6 +54,7 @@ export default function Home() {
       body: JSON.stringify({
   email: mappedEmail,
   password: mappedPassword,
+  name: mappedName,
   userType: mappedUserType,
 })
 
@@ -118,12 +120,13 @@ export default function Home() {
           <div className="text-sm text-emerald-600 mb-4">
               <select
                 value={registerForm?.userType || ""}
-                onChange={(e) => setRegisterForm({
-                  email: registerForm?.email,
-                  password: registerForm?.password,
-                  userType: e.target.value as "influencer" | "restaurant"
-                })
-                }
+                  onChange={(e) => setRegisterForm({
+                    email: registerForm?.email,
+                    password: registerForm?.password,
+                    name: registerForm?.name,
+                    userType: e.target.value as "influencer" | "restaurant"
+                  })
+                  }
                 className="w-full max-w-sm px-4 py-2 border border-emerald-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500 text-emerald-800 bg-white"
               >
                 <option value="" disabled>Select User Type</option>
@@ -141,6 +144,19 @@ export default function Home() {
                 onChange={(e) => setRegisterForm({
                   email: e.target.value,
                   password: registerForm?.password,
+                  name: registerForm?.name,
+                  userType: registerForm?.userType
+                })}
+                className="w-full max-w-sm px-4 py-2 border border-emerald-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500 text-emerald-800 bg-white placeholder-emerald-400"
+              />
+              <input
+                type="text"
+                placeholder="Name"
+                value={registerForm?.name || ""}
+                onChange={(e) => setRegisterForm({
+                  email: registerForm?.email,
+                  password: registerForm?.password,
+                  name: e.target.value,
                   userType: registerForm?.userType
                 })}
                 className="w-full max-w-sm px-4 py-2 border border-emerald-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500 text-emerald-800 bg-white placeholder-emerald-400"
@@ -152,6 +168,7 @@ export default function Home() {
                 onChange={(e) => setRegisterForm({
                   email: registerForm?.email,
                   password: e.target.value,
+                  name: registerForm?.name,
                   userType: registerForm?.userType
                 })}
                 className="w-full max-w-sm px-4 py-2 border border-emerald-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500 text-emerald-800 bg-white placeholder-emerald-400"
@@ -165,7 +182,7 @@ export default function Home() {
                   </div>
                   <button
                     onClick={handleSignUp}
-                    disabled={!registerForm?.email || !registerForm?.password || !registerForm?.userType || !registerForm || registerForm.password.length < 6}
+                    disabled={!registerForm?.email || !registerForm?.password || !registerForm?.userType || !registerForm?.name || !registerForm || registerForm.password.length < 6}
                     className="mt-4 px-6 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 transition-colors"
                   >
                     Sign Up

--- a/src/app/restaurant/page.tsx
+++ b/src/app/restaurant/page.tsx
@@ -51,7 +51,7 @@ export default function RestaurantDiscountDashboard() {
   const [filterStatus, setFilterStatus] = useState<DiscountStatus | "all">("all");
   const [availableItems, setAvailableItems] = useState<Item[]>([]);
   const [itemsByDiscountId, setItemsByDiscountId] = useState<Record<number, Item[]>>({});
-const [user, setUser] = useState<{ email: string } | null>(null);
+const [user, setUser] = useState<{ email: string, name: string } | null>(null);
   const [tab, setTab] = useState(0);
   const [expandedRows, setExpandedRows] = useState<Record<number, boolean>>({});
   const [editingId, setEditingId] = useState<number | null>(null);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,7 +18,7 @@ export const authOptions: AuthOptions = {
         if (!credentials?.email || !credentials?.password) return null;
         const user = await prisma.user.findUnique({ where: { email: credentials.email } });
         if (!user || !(await bcrypt.compare(credentials.password, user.password))) return null;
-        return { id: user.id, email: user.email, userType: user.userType };
+        return { id: user.id, email: user.email, name: user.name, userType: user.userType };
       },
     }),
   ],


### PR DESCRIPTION
## Summary
- allow users to provide their name during signup
- store name in the DB and include it in auth payloads
- expose name in `/api/auth/me`
- display and submit name in the registration form
- keep restaurant dashboard user type in sync

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6888b52d54a883259ce33b44a4b09d43