### PR TITLE
Add submit guard when restaurant missing

### DIFF
--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -307,10 +307,16 @@ export default function UserPage() {
 
               <button
                 type="submit"
-                className="w-full py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold rounded-xl text-sm transition-all duration-200"
+                disabled={!selectedRestaurant}
+                className="w-full py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold rounded-xl text-sm transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {verifying ? '⏳ Verifying post...' : '🎬 Submit post'}
               </button>
+              {!selectedRestaurant && (
+                <p className="text-xs text-emerald-600 mt-1">
+                  Please select a restaurant to submit.
+                </p>
+              )}
             </form>
           )}
 


### PR DESCRIPTION
## Summary
- disable the post submission button until a restaurant is selected
- show helper text prompting users to pick a restaurant first

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6888d09fe840832583c02e144c28f776