### PR TITLE
Add privacy policy page and footer link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,19 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Providers>{children}</Providers>
+        <Providers>
+          <div className="flex min-h-screen flex-col">
+            <main className="flex-grow">{children}</main>
+            <footer className="p-4 text-center text-xs text-gray-500">
+              <a
+                href="/privacy-policy"
+                className="underline hover:text-gray-700"
+              >
+                Privacy Policy
+              </a>
+            </footer>
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+};
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="mx-auto max-w-3xl p-4">
+      <h1 className="mb-4 text-2xl font-bold">Privacy Policy</h1>
+      <p className="mb-2">Last updated: January 1, 2025</p>
+      <p className="mb-2">
+        This Privacy Policy explains how we collect, use, and share your personal
+        information when you use Discounter.
+      </p>
+      <h2 className="mt-6 mb-2 text-xl font-semibold">Information We Collect</h2>
+      <p className="mb-2">
+        We collect information you provide directly to us, such as when you
+        create an account or contact support.
+      </p>
+      <h2 className="mt-6 mb-2 text-xl font-semibold">How We Use Information</h2>
+      <p className="mb-2">
+        We use the information to operate and improve our services, communicate
+        with you, and comply with legal obligations.
+      </p>
+      <h2 className="mt-6 mb-2 text-xl font-semibold">Contact Us</h2>
+      <p>
+        If you have any questions about this policy, you can contact us at
+        support@example.com.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add global footer with link to privacy policy
- introduce dedicated privacy policy page describing data collection, usage, and contact info

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; installation attempt returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_6894466707a88325abdf485e0b151995