### PR TITLE
Ensure dropdown and checkbox text uses dark green styling

### DIFF
--- a/src/app/restaurant/page.tsx
+++ b/src/app/restaurant/page.tsx
@@ -469,36 +469,36 @@ const [user, setUser] = useState<{ email: string, name: string } | null>(null);
      </label>
    </div>
    <div className="mt-6">
-     <label className="font-medium text-emerald-800">Applicable Items:</label>
-     <div className="flex flex-wrap gap-3 mt-2">
-       {availableItems.map((item, idx) => {
-         const selected = editForm.items.some((i) => i.id === item.id);
-         return (
-           <label
-             key={idx}
-             className={`px-3 py-1 rounded-full text-sm cursor-pointer ${
-               selected ? "bg-emerald-100 border-2 border-emerald-600" : "bg-gray-50 border border-gray-300"
-             }`}
-           >
-             <input
-               type="checkbox"
-               checked={selected}
-               onChange={() =>
-                 selected
-                   ? setEditForm({
-                       ...editForm,
-                       items: editForm.items.filter((i) => i.id !== item.id),
-                     })
-                   : setEditForm({ ...editForm, items: [...editForm.items, item] })
-               }
-               className="mr-2"
-             />
-             {item.name}
-           </label>
-         );
-       })}
-     </div>
-   </div>
+    <label className="font-medium text-emerald-800">Applicable Items:</label>
+    <div className="flex flex-wrap gap-3 mt-2">
+      {availableItems.map((item, idx) => {
+        const selected = editForm.items.some((i) => i.id === item.id);
+        return (
+          <label
+            key={idx}
+            className={`px-3 py-1 rounded-full text-sm cursor-pointer text-emerald-800 ${
+              selected ? "bg-emerald-100 border-2 border-emerald-600" : "bg-gray-50 border border-gray-300"
+            }`}
+          >
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={() =>
+                selected
+                  ? setEditForm({
+                      ...editForm,
+                      items: editForm.items.filter((i) => i.id !== item.id),
+                    })
+                  : setEditForm({ ...editForm, items: [...editForm.items, item] })
+              }
+              className="mr-2 accent-emerald-600"
+            />
+            {item.name}
+          </label>
+        );
+      })}
+    </div>
+  </div>
 
    <div className="mt-10 border-t border-emerald-300 pt-6">
      <h3 className="text-lg font-semibold text-emerald-800 mb-4">Requirements</h3>
@@ -662,7 +662,7 @@ const [user, setUser] = useState<{ email: string, name: string } | null>(null);
         return (
           <label
             key={idx}
-            className={`px-3 py-1 rounded-full text-sm cursor-pointer ${
+            className={`px-3 py-1 rounded-full text-sm cursor-pointer text-emerald-800 ${
               selected
                 ? "bg-emerald-100 border-2 border-emerald-600"
                 : "bg-gray-50 border border-gray-300"
@@ -681,7 +681,7 @@ const [user, setUser] = useState<{ email: string, name: string } | null>(null);
                   items: [...form.items, item]
                 })
               }
-              className="mr-2"
+              className="mr-2 accent-emerald-600"
             />
             {item.name}
           </label>

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -217,12 +217,12 @@ export default function UserPage() {
                     className="w-full px-4 py-2 rounded-xl border border-emerald-300 bg-white text-emerald-800 placeholder-emerald-400 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
                   />
                   {restaurantResults.length > 0 && (
-                    <ul className="border border-emerald-300 rounded-xl mt-1 bg-white max-h-40 overflow-auto text-sm">
+                    <ul className="border border-emerald-300 rounded-xl mt-1 bg-white max-h-40 overflow-auto text-sm text-emerald-800">
                       {restaurantResults.map((r) => (
                         <li
                           key={r.id}
                           onClick={() => { setSelectedRestaurant(r); setRestaurantQuery(r.name); setRestaurantResults([]); }}
-                          className="px-3 py-1 cursor-pointer hover:bg-emerald-50"
+                          className="px-3 py-1 cursor-pointer hover:bg-emerald-50 text-emerald-800"
                         >
                           {r.name}
                         </li>


### PR DESCRIPTION
## Summary
- Ensure restaurant search dropdown text is dark green on all devices
- Style restaurant dashboard item checkboxes with dark green text and accents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_6895a0e75f1c8325a13f6f1431b14523