### PR TITLE
Fetch restaurant discounts instead of mock data

### DIFF
--- a/src/app/api/discounts/route.ts
+++ b/src/app/api/discounts/route.ts
@@ -7,7 +7,25 @@ import { authOptions } from "@/lib/auth";
 
 const prisma = new PrismaClient();
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const restaurantId = req.nextUrl.searchParams.get("restaurantId");
+  if (restaurantId) {
+    try {
+      const discounts = await prisma.discountCode.findMany({
+        where: { restaurantId: Number(restaurantId) },
+        include: {
+          applicableItems: {
+            include: { item: true },
+          },
+        },
+      });
+      return NextResponse.json(discounts);
+    } catch (err) {
+      console.error("Error fetching discounts by restaurant:", err);
+      return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+  }
+
   const session = await getServerSession(authOptions);
   console.log("Fetching discounts for session:", session);
   if (!session || !["restaurant", "business"].includes(session.user.userType)) {


### PR DESCRIPTION
## Summary
- query API for a restaurant's discount codes instead of using hardcoded mocks
- allow `/api/discounts` to accept a `restaurantId` param for public lookups

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/picomatch)*

------
https://chatgpt.com/codex/tasks/task_e_689c5f7cfce4832582d87b72fadd826b