### PR TITLE
Highlight used discounts and show redeemer

### DIFF
--- a/src/app/api/discounts/route.ts
+++ b/src/app/api/discounts/route.ts
@@ -17,6 +17,9 @@ export async function GET(req: NextRequest) {
           applicableItems: {
             include: { item: true },
           },
+          redemptions: {
+            include: { influencer: { select: { name: true } } },
+          },
         },
       });
       return NextResponse.json(discounts);
@@ -38,6 +41,9 @@ export async function GET(req: NextRequest) {
       include: {
         applicableItems: {
           include: { item: true },
+        },
+        redemptions: {
+          include: { influencer: { select: { name: true } } },
         },
       },
     });


### PR DESCRIPTION
## Summary
- highlight used discount codes with orange styling
- display the influencer name for used codes when expanding details
- include redemption info with influencer names in discount API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; `npm install` 403s)*

------
https://chatgpt.com/codex/tasks/task_e_689c81a5cab88325b52bab79b4a87385