### PR TITLE
Display awarded users and process scanned codes

### DIFF
--- a/src/app/api/discounts/use/route.ts
+++ b/src/app/api/discounts/use/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { PrismaClient, DiscountStatus } from "@/generated/client";
+
+const prisma = new PrismaClient();
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["restaurant", "business"].includes(session.user.userType)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { codeId } = await req.json();
+  if (!codeId) {
+    return NextResponse.json({ error: "codeId required" }, { status: 400 });
+  }
+
+  try {
+    const discount = await prisma.discountCode.update({
+      where: { id: Number(codeId) },
+      data: { status: DiscountStatus.used },
+    });
+
+    await prisma.redemption.updateMany({
+      where: { discountCodeId: Number(codeId) },
+      data: { status: DiscountStatus.used, redeemedAt: new Date() },
+    });
+
+    return NextResponse.json(discount);
+  } catch (err) {
+    console.error("Error using discount:", err);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Fix cashier page to show awarded user when code status is awarded
- Hide scan button until after code validation and show positive requirement check
- Add API route and frontend action to mark scanned discount codes as used

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/picomatch)


------
https://chatgpt.com/codex/tasks/task_e_689c97e2c36483258fd3e800b269a87e