### PR TITLE
fix: expose Facebook app ID for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Environment Variables
+
+To enable Facebook/Instagram authentication, configure the following variable in your environment:
+
+```bash
+NEXT_PUBLIC_FACEBOOK_APP_ID=your_app_id_here
+```
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -109,7 +109,11 @@ export default function Home() {
   };
 
   const handleInstagramConnect = () => {
-    const appId = process.env.NEXT_FACEBOOK_APP_ID;
+    const appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID;
+    if (!appId) {
+      alert("Facebook App ID is not configured.");
+      return;
+    }
     const redirectUri = `${window.location.origin}`;
     const scope = "instagram_basic,pages_show_list";
 


### PR DESCRIPTION
## Summary
- use NEXT_PUBLIC_FACEBOOK_APP_ID for Instagram OAuth
- document Facebook app ID environment variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a5808270c483258b5b918e8e97fda5