### PR TITLE
Update Instagram connect flow for new app

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ### Environment Variables
 
-To enable Facebook/Instagram authentication, configure the following variable in your environment:
+To enable Facebook/Instagram authentication, configure the following variables in your environment:
 
 ```bash
-NEXT_PUBLIC_FACEBOOK_APP_ID=your_app_id_here
+NEXT_PUBLIC_FACEBOOK_APP_ID=788193503894407
+FACEBOOK_APP_SECRET=your_app_secret_here
 ```
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/src/app/api/instagram/token/route.ts
+++ b/src/app/api/instagram/token/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const code = req.nextUrl.searchParams.get("code");
+  const appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID ?? "788193503894407";
+  const appSecret = process.env.FACEBOOK_APP_SECRET;
+  if (!code || !appId || !appSecret) {
+    return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
+  }
+  const redirectUri = `${req.nextUrl.origin}/instagram-callback`;
+  const tokenRes = await fetch(
+    `https://graph.facebook.com/v19.0/oauth/access_token?client_id=${appId}&client_secret=${appSecret}&redirect_uri=${encodeURIComponent(redirectUri)}&code=${code}`,
+  );
+  const data = await tokenRes.json();
+  return NextResponse.json(data);
+}

--- a/src/app/instagram-callback/page.tsx
+++ b/src/app/instagram-callback/page.tsx
@@ -3,12 +3,21 @@ import { useEffect } from "react";
 
 export default function InstagramCallback() {
   useEffect(() => {
-    const hash = window.location.hash.substring(1);
-    const params = new URLSearchParams(hash);
-    const token = params.get("access_token");
-    if (token && window.opener) {
-      window.opener.postMessage({ type: "instagram-token", token }, window.location.origin);
-      window.close();
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    if (code && window.opener) {
+      fetch(`/api/instagram/token?code=${code}`)
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.access_token) {
+            window.opener.postMessage(
+              { type: "instagram-token", token: data.access_token },
+              window.location.origin,
+            );
+          }
+          window.close();
+        })
+        .catch(() => window.close());
     }
   }, []);
   return <p>Connecting to Instagram...</p>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -124,15 +124,18 @@ export default function Home() {
   };
 
   const handleInstagramConnect = () => {
-    const appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID;
+    const appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID ?? "788193503894407";
     if (!appId) {
       alert("Facebook App ID is not configured.");
       return;
     }
     const redirectUri = `${window.location.origin}/instagram-callback`;
-    const scope = "instagram_basic,pages_show_list";
+    const scope =
+      "instagram_basic,instagram_manage_messages,instagram_content_publish,pages_show_list";
 
-    const authUrl = `https://www.facebook.com/v19.0/dialog/oauth?client_id=${appId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}&response_type=token`;
+    const authUrl = `https://www.facebook.com/v19.0/dialog/oauth?client_id=${appId}&redirect_uri=${encodeURIComponent(
+      redirectUri,
+    )}&scope=${encodeURIComponent(scope)}&response_type=code`;
 
     const popup = window.open(authUrl, "instagramLogin", "width=600,height=700");
 


### PR DESCRIPTION
## Summary
- switch registration page to authorization code flow for Instagram with extended messaging/content scopes
- add API route to exchange authorization codes for tokens using new Facebook app
- document required Facebook app id and secret

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/picomatch)*

------
https://chatgpt.com/codex/tasks/task_e_68aad5718f188325b27616ea4bbccbf6