### PR TITLE
fix: update instagram oauth config and defaults

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -11,7 +11,8 @@ FACEBOOK_CLIENT_SECRET=your_facebook_app_secret
 FACEBOOK_API_VERSION=v23.0
 FACEBOOK_OAUTH_SCOPES=public_profile,email,pages_show_list,pages_read_engagement,instagram_basic,instagram_manage_insights
 
-# Client-side Facebook vars
-NEXT_PUBLIC_FACEBOOK_APP_ID=your_facebook_app_id
-NEXT_PUBLIC_FACEBOOK_API_VERSION=v23.0
-NEXT_PUBLIC_FACEBOOK_SCOPE=instagram_basic
+# Client-side Instagram vars
+NEXT_PUBLIC_INSTAGRAM_APP_ID=your_instagram_app_id
+# Optional: fallback to Facebook config if needed
+# NEXT_PUBLIC_FACEBOOK_APP_ID=your_facebook_app_id
+NEXT_PUBLIC_INSTAGRAM_SCOPE=user_profile,user_media

--- a/src/app/api/meta/callback/route.ts
+++ b/src/app/api/meta/callback/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-const FB_API_VERSION = process.env.FACEBOOK_API_VERSION!;
+const FB_API_VERSION = process.env.FACEBOOK_API_VERSION || "v23.0";
 const G = (p: Record<string, string>) => new URLSearchParams(p).toString();
 
 export async function GET(req: NextRequest) {

--- a/src/app/api/meta/login/route.ts
+++ b/src/app/api/meta/login/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import crypto from "crypto";
 
-const FB_API_VERSION = process.env.FACEBOOK_API_VERSION!;
-const FB_OAUTH_SCOPES = process.env.FACEBOOK_OAUTH_SCOPES!;
+const FB_OAUTH_SCOPES =
+  process.env.FACEBOOK_OAUTH_SCOPES ||
+  "public_profile,email,pages_show_list,pages_read_engagement,instagram_basic,instagram_manage_insights";
 
 export async function GET() {
   const state = crypto.randomBytes(16).toString("hex");
@@ -20,6 +21,6 @@ export async function GET() {
   });
 
   return NextResponse.redirect(
-    `https://www.facebook.com/${FB_API_VERSION}/dialog/oauth?${params.toString()}`
+    `https://api.instagram.com/oauth/authorize?${params.toString()}`
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -124,23 +124,26 @@ export default function Home() {
   };
 
   const handleInstagramConnect = () => {
-    const appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID;
+    const appId =
+      process.env.NEXT_PUBLIC_INSTAGRAM_APP_ID ||
+      process.env.NEXT_PUBLIC_FACEBOOK_APP_ID;
     if (!appId) {
-      alert("Facebook App ID is not configured.");
+      alert("Instagram App ID is not configured.");
       return;
     }
     const redirectUri = `${window.location.origin}/instagram-callback`;
-    const scope = process.env.NEXT_PUBLIC_FACEBOOK_SCOPE;
-    const apiVersion = process.env.NEXT_PUBLIC_FACEBOOK_API_VERSION;
+    const scope =
+      process.env.NEXT_PUBLIC_INSTAGRAM_SCOPE ||
+      process.env.NEXT_PUBLIC_FACEBOOK_SCOPE ||
+      "user_profile,user_media";
 
-    if (!scope || !apiVersion) {
-      alert("Facebook OAuth configuration is missing.");
-      return;
-    }
+    const authUrl = `https://api.instagram.com/oauth/authorize?client_id=${appId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}&response_type=token`;
 
-    const authUrl = `https://www.facebook.com/${apiVersion}/dialog/oauth?client_id=${appId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent(scope)}&response_type=token`;
-
-    const popup = window.open(authUrl, "instagramLogin", "width=600,height=700");
+    const popup = window.open(
+      authUrl,
+      "instagramLogin",
+      "popup=yes,width=600,height=700,menubar=no,toolbar=no,location=no,status=no"
+    );
 
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;


### PR DESCRIPTION
## Summary
- switch login flow to use Instagram auth endpoint
- fallback to default API version & scope when env vars missing
- ensure Instagram connect uses popup dialog

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ac76e7dd9c8325a5dcabcbc10706a3