### PR TITLE
Handle duplicate discount requests from influencers

### DIFF
--- a/src/app/api/discounts/request/route.ts
+++ b/src/app/api/discounts/request/route.ts
@@ -79,6 +79,23 @@ export async function POST(req: NextRequest) {
   }
 
   if (discount.status !== DiscountStatus.available) {
+    const alreadyRequestedByInfluencer =
+      discount.status === DiscountStatus.requested &&
+      Array.isArray(discount.redemptions) &&
+      discount.redemptions.some((redemption: any) => {
+        const requesterId = Number(
+          (redemption as any).influencerId ?? redemption.influencer?.id
+        );
+        return (
+          redemption.status === DiscountStatus.requested &&
+          requesterId === influencerId
+        );
+      });
+
+    if (alreadyRequestedByInfluencer) {
+      return NextResponse.json({ discount, previousCodeId: parsedCodeId, alreadyRequested: true });
+    }
+
     return NextResponse.json({ error: "Discount not available" }, { status: 400 });
   }
 


### PR DESCRIPTION
## Summary
- prevent /api/discounts/request from returning an error when the requesting influencer already has a pending request for the same code
- return the existing discount payload when a duplicate request is detected instead of a 400 response

## Testing
- Not run (npm install failed: 403 Forbidden fetching picomatch)


------
https://chatgpt.com/codex/tasks/task_e_68d8d9f390308325a44c1b57271f2184