### PR TITLE
Improve request review flows for influencers and cashiers

### DIFF
--- a/src/app/api/discounts/decision/route.ts
+++ b/src/app/api/discounts/decision/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { DiscountStatus, PrismaClient } from "@/generated/client";
+
+const prisma = new PrismaClient();
+
+const discountInclude = {
+  applicableItems: {
+    include: {
+      item: true,
+    },
+  },
+  redemptions: {
+    include: {
+      influencer: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+    },
+  },
+};
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || !["restaurant", "business"].includes(session.user.userType)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const { codeId, decision } = body ?? {};
+  const parsedCodeId = Number(codeId);
+
+  if (!codeId || Number.isNaN(parsedCodeId) || !["approve", "reject"].includes(decision)) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  try {
+    if (decision === "approve") {
+      const updatedDiscount = await prisma.$transaction(async (tx) => {
+        await tx.redemption.updateMany({
+          where: { discountCodeId: parsedCodeId, status: DiscountStatus.requested },
+          data: { status: DiscountStatus.awarded },
+        });
+
+        return tx.discountCode.update({
+          where: { id: parsedCodeId },
+          data: { status: DiscountStatus.awarded },
+          include: discountInclude,
+        });
+      });
+
+      return NextResponse.json({ discount: updatedDiscount });
+    }
+
+    const updatedDiscount = await prisma.$transaction(async (tx) => {
+      await tx.redemption.deleteMany({
+        where: { discountCodeId: parsedCodeId },
+      });
+
+      return tx.discountCode.update({
+        where: { id: parsedCodeId },
+        data: { status: DiscountStatus.available },
+        include: discountInclude,
+      });
+    });
+
+    return NextResponse.json({ discount: updatedDiscount });
+  } catch (error) {
+    console.error("Failed to update discount decision", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -14,7 +14,6 @@ export default function UserPage() {
   const [reelLink, setReelLink] = useState('');
   const [verifying, setVerifying] = useState(false);
   const [requestingCodeId, setRequestingCodeId] = useState<number | null>(null);
-  const [hoveredCodeId, setHoveredCodeId] = useState<number | null>(null);
   const [tab, setTab] = useState<0 | 1>(0);
   const [uploadedImage, setUploadedImage] = useState<File | null>(null);
   const [platform, setPlatform] = useState<'instagram' | 'tiktok'>('instagram');
@@ -259,7 +258,11 @@ export default function UserPage() {
     );
   };
 
-  const filteredMyDiscounts = myDiscounts
+  const visibleMyDiscounts = myDiscounts.filter((d) =>
+    ["available", "requested"].includes(d.status)
+  );
+
+  const filteredMyDiscounts = visibleMyDiscounts
     .filter((d) => d.code.toLowerCase().includes(search.toLowerCase()))
     .filter((d) => (statusFilter === 'all' ? true : d.status === statusFilter));
 
@@ -362,16 +365,13 @@ export default function UserPage() {
                     <tbody>
                       {eligibleDiscounts.map((d, idx) => {
                         const isRequested = isRequestedByCurrentUser(d);
-                        const isHovered = hoveredCodeId === d.id;
                         const isProcessing = requestingCodeId === d.id;
                         const buttonLabel = isProcessing
                           ? isRequested
                             ? 'Updating...'
                             : 'Requesting...'
                           : isRequested
-                            ? isHovered
-                              ? 'Cancel Request'
-                              : 'Requested'
+                            ? 'Cancel Request'
                             : 'Request';
                         const buttonAction = isRequested ? 'cancel' : 'request';
                         const requirements = extractRequirements(d.requirements);
@@ -398,8 +398,6 @@ export default function UserPage() {
                               <td className="p-3 text-right">
                                 <button
                                   type="button"
-                                  onMouseEnter={() => setHoveredCodeId(d.id)}
-                                  onMouseLeave={() => setHoveredCodeId(null)}
                                   onClick={() => handleRequest(d.id, buttonAction)}
                                   disabled={isProcessing}
                                   className={`px-3 py-1 rounded transition-colors ${
@@ -635,11 +633,9 @@ export default function UserPage() {
             onChange={(e) => setStatusFilter(e.target.value as DiscountStatus | 'all')}
             className="w-full px-4 py-2 rounded-xl border border-emerald-300 bg-white text-emerald-800 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
           >
-            <option value="requested">Requested</option>
-            <option value="awarded">Awarded</option>
-            <option value="used">Used</option>
-            <option value="expired">Expired</option>
             <option value="all">All</option>
+            <option value="available">Available</option>
+            <option value="requested">Requested</option>
           </select>
         </div>
         <ul className="space-y-3">


### PR DESCRIPTION
## Summary
- limit the influencer dashboard to available and requested codes and show an explicit Cancel Request action
- redesign the cashier workflow to select pending requests, review hard-coded engagement metrics, and choose an approval decision
- add an API endpoint for restaurants to approve or reject a request and update the discount code state accordingly

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eb9370788325be70ceadaa01dd70