### PR TITLE
Add restaurant-specific menu data and selection

### DIFF
--- a/src/app/api/restaurants/[id]/route.ts
+++ b/src/app/api/restaurants/[id]/route.ts
@@ -1,11 +1,12 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
 export async function GET(
-  _req: NextRequest,
-  { params }: { params: { id: string } }
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const id = Number(params.id);
+  const { id: paramId } = await params;
+  const id = Number(paramId);
   if (!Number.isInteger(id)) {
     return NextResponse.json(
       { error: 'Invalid restaurant id' },

--- a/src/app/data/restaurants/gymJunkie.ts
+++ b/src/app/data/restaurants/gymJunkie.ts
@@ -1,0 +1,102 @@
+import { RestaurantMenu } from "../../types/menu";
+
+const gymJunkie: RestaurantMenu = {
+  id: "gymJunkie",
+  name: "Gym Junkie",
+  cuisine: "Performance bowls & protein plates",
+  tagline: "Macros made delicious for lifters and runners alike",
+  ingredients: [
+    { name: "Chargrilled chicken breast", notes: "Brined for juiciness" },
+    { name: "Roasted sweet potato", notes: "Slow-roasted with smoked paprika" },
+    { name: "Quinoa blend", notes: "Tri-color quinoa with toasted seeds" },
+    { name: "Grass-fed flank steak", notes: "Marinated in tamari and lime" },
+  ],
+  recipes: [
+    {
+      name: "Power Bowl Base",
+      description: "Balanced carbohydrates, lean protein, and greens for refuel days.",
+      ingredients: ["quinoa blend", "pickled cucumber", "edamame", "roasted sweet potato"],
+      steps: [
+        "Steam quinoa with bay leaf, fold in toasted seeds.",
+        "Roast sweet potato wedges with paprika until caramelized.",
+        "Assemble with chilled edamame, cucumber, and protein of choice.",
+      ],
+    },
+    {
+      name: "Lean Steak Marinade",
+      description: "Umami-heavy tamari and lime marinade to keep steak tender.",
+      ingredients: ["tamari", "lime zest", "garlic", "black pepper"],
+      steps: [
+        "Whisk ingredients with a splash of olive oil.",
+        "Marinate flank steak for 6–8 hours, then grill hard and slice thin.",
+        "Finish with fresh herbs and flaky salt.",
+      ],
+    },
+  ],
+  menuCourses: [
+    {
+      title: "Power Bowls",
+      description: "Heavy on protein, light on fuss",
+      items: [
+        {
+          name: "Green Machine",
+          price: 13,
+          description: "Grilled chicken, quinoa blend, broccoli, herb tahini, pickled onion",
+          tags: ["high protein"],
+        },
+        {
+          name: "Teriyaki Tofu Crunch",
+          price: 12,
+          description: "Marinated tofu, brown rice, edamame, sesame greens, cashew crumble",
+          tags: ["plant-based"],
+        },
+        {
+          name: "Steak & Sweet Potato",
+          price: 15,
+          description: "Flank steak, roasted sweet potato, grilled zucchini, chimichurri yogurt",
+        },
+      ],
+    },
+    {
+      title: "Protein Plates",
+      description: "Straightforward portions for training days",
+      items: [
+        {
+          name: "Lemon Pepper Chicken",
+          price: 14,
+          description: "Two fire-grilled breasts, garlic green beans, herb quinoa",
+        },
+        {
+          name: "Salmon Performance Plate",
+          price: 17,
+          description: "Roasted salmon, citrus farro, shaved fennel salad",
+          tags: ["omega-3"],
+        },
+        {
+          name: "BBQ Jackfruit Loaded Fries",
+          price: 11,
+          description: "Baked sweet potato fries, pulled jackfruit, smoky BBQ glaze",
+          tags: ["plant-based"],
+        },
+      ],
+    },
+    {
+      title: "Shakes & Boosters",
+      description: "Smooth recovery in a glass",
+      items: [
+        {
+          name: "Peanut Butter Bulk",
+          price: 8,
+          description: "Whey or pea protein, banana, peanut butter, flax, oat milk",
+        },
+        {
+          name: "Berry Recharge",
+          price: 7,
+          description: "Mixed berries, coconut water, collagen boost, mint",
+        },
+      ],
+    },
+  ],
+};
+
+export default gymJunkie;

--- a/src/app/data/restaurants/index.ts
+++ b/src/app/data/restaurants/index.ts
@@ -1,0 +1,16 @@
+import gymJunkie from "./gymJunkie";
+import moccavenlo from "./moccavenlo";
+import pokelab from "./pokelab";
+import preps from "./preps";
+import superbros from "./superbros";
+import { RestaurantMenu } from "../../types/menu";
+
+export const restaurantMenus: Record<string, RestaurantMenu> = {
+  [superbros.id]: superbros,
+  [gymJunkie.id]: gymJunkie,
+  [pokelab.id]: pokelab,
+  [preps.id]: preps,
+  [moccavenlo.id]: moccavenlo,
+};
+
+export const restaurantMenuList: RestaurantMenu[] = Object.values(restaurantMenus);

--- a/src/app/data/restaurants/moccavenlo.ts
+++ b/src/app/data/restaurants/moccavenlo.ts
@@ -1,0 +1,98 @@
+import { RestaurantMenu } from "../../types/menu";
+
+const moccavenlo: RestaurantMenu = {
+  id: "moccavenlo",
+  name: "Moccavenlo",
+  cuisine: "Café brunch & slow coffee",
+  tagline: "Seasonal pastries, specialty beans, and cozy brunch plates",
+  ingredients: [
+    { name: "Single-origin espresso", source: "Rotating roasters", notes: "Dialed in weekly" },
+    { name: "Sourdough starter", notes: "Levain used for all house breads" },
+    { name: "Free-range eggs", notes: "Soft-poached to order" },
+    { name: "House granola", notes: "Toasted oats, seeds, and citrus peel" },
+  ],
+  recipes: [
+    {
+      name: "Citrus Cardamom Syrup",
+      description: "Signature syrup for lattes and iced spritzers.",
+      ingredients: ["orange peel", "cardamom pods", "demerara sugar", "vanilla"],
+      steps: [
+        "Simmer sugar with water and cardamom for 10 minutes.",
+        "Add orange peel and vanilla; steep until fragrant and strain.",
+      ],
+    },
+    {
+      name: "Sourdough Pancake Batter",
+      description: "Overnight batter that yields tangy, fluffy stacks.",
+      ingredients: ["sourdough starter", "buttermilk", "eggs", "flour", "maple"],
+      steps: [
+        "Whisk starter with buttermilk and rest overnight.",
+        "Fold in eggs and flour before service; griddle with cultured butter.",
+      ],
+    },
+  ],
+  menuCourses: [
+    {
+      title: "Coffee Bar",
+      description: "Specialty espresso and slow brew",
+      items: [
+        {
+          name: "Flat White",
+          price: 4,
+          description: "Double ristretto with silky steamed milk",
+        },
+        {
+          name: "V60 Pour Over",
+          price: 5,
+          description: "Rotating single-origin, hand-poured to highlight terroir",
+        },
+        {
+          name: "Citrus Cardamom Latte",
+          price: 5.5,
+          description: "House syrup, micro-foam, dusted with dehydrated orange",
+          tags: ["signature"],
+        },
+      ],
+    },
+    {
+      title: "Brunch Plates",
+      description: "Comfort food with café finesse",
+      items: [
+        {
+          name: "Sourdough Avocado Toast",
+          price: 11,
+          description: "Poached egg, chili crisp, pickled shallot, garden herbs",
+        },
+        {
+          name: "Smoked Salmon Benny",
+          price: 13,
+          description: "House hollandaise, greens, lemony hash browns",
+        },
+        {
+          name: "Sourdough Pancakes",
+          price: 10,
+          description: "Cultured butter, maple, macerated berries",
+          tags: ["vegetarian"],
+        },
+      ],
+    },
+    {
+      title: "Bakery & Sweets",
+      description: "Daily pastries and small desserts",
+      items: [
+        {
+          name: "Cardamom Bun",
+          price: 4,
+          description: "Lamined bun with brown sugar cardamom filling",
+        },
+        {
+          name: "Salted Caramel Brownie",
+          price: 4.5,
+          description: "Fudgy brownie, espresso salt, toasted pecans",
+        },
+      ],
+    },
+  ],
+};
+
+export default moccavenlo;

--- a/src/app/data/restaurants/pokelab.ts
+++ b/src/app/data/restaurants/pokelab.ts
@@ -1,0 +1,99 @@
+import { RestaurantMenu } from "../../types/menu";
+
+const pokelab: RestaurantMenu = {
+  id: "pokelab",
+  name: "Pokelab",
+  cuisine: "Hawaiian poke with Japanese precision",
+  tagline: "Build-your-own bowls with market-fresh fish",
+  ingredients: [
+    { name: "Sashimi-grade salmon", source: "Nordic farms", notes: "Trimmed in-house daily" },
+    { name: "Line-caught ahi tuna", notes: "Marinated to order" },
+    { name: "Jasmine rice", notes: "Fluffy base for every bowl" },
+    { name: "Shoyu ponzu", notes: "Citrus-forward soy blend" },
+  ],
+  recipes: [
+    {
+      name: "Classic Shoyu Marinade",
+      description: "A balanced soy marinade that keeps fish silky.",
+      ingredients: ["light soy", "ponzu", "mirin", "scallion", "sesame oil"],
+      steps: [
+        "Combine liquids with toasted sesame oil.",
+        "Fold in scallions right before tossing fish to keep them bright.",
+        "Marinate diced fish for 10 minutes to season without cooking it.",
+      ],
+    },
+    {
+      name: "Ginger Miso Dressing",
+      description: "Creamy dressing for greens-forward bowls.",
+      ingredients: ["white miso", "ginger", "rice vinegar", "honey", "sunflower oil"],
+      steps: [
+        "Blend all ingredients until glossy and smooth.",
+        "Adjust acidity with rice vinegar and finish with toasted sesame seeds.",
+      ],
+    },
+  ],
+  menuCourses: [
+    {
+      title: "Signature Bowls",
+      description: "Curated combos so you don’t have to choose",
+      items: [
+        {
+          name: "Ahi Classic",
+          price: 15,
+          description: "Shoyu ahi tuna, jasmine rice, seaweed salad, crispy shallots, sesame",
+          tags: ["classic"],
+        },
+        {
+          name: "Salmon Ponzu",
+          price: 15,
+          description: "Citrus ponzu salmon, avocado, pickled ginger, edamame, furikake",
+        },
+        {
+          name: "Tofu Ginger Crunch",
+          price: 13,
+          description: "Ginger miso tofu, brown rice, cucumber ribbons, crunchy lotus chips",
+          tags: ["vegan"],
+        },
+      ],
+    },
+    {
+      title: "Build Your Own",
+      description: "Pick a base, protein, sauce, and crisp toppings",
+      items: [
+        {
+          name: "Base Choices",
+          price: 0,
+          description: "Jasmine rice, brown rice, or mixed greens",
+        },
+        {
+          name: "Proteins",
+          price: 0,
+          description: "Ahi tuna, salmon, spicy prawn, marinated tofu",
+        },
+        {
+          name: "Sauces",
+          price: 0,
+          description: "Shoyu ponzu, gochujang mayo, ginger miso, yuzu kosho",
+        },
+      ],
+    },
+    {
+      title: "Sides & Sips",
+      description: "Crunchy bites and refreshing drinks",
+      items: [
+        {
+          name: "Kimchi Cucumber",
+          price: 5,
+          description: "Quick-pickled cucumber with kimchi spice and sesame",
+        },
+        {
+          name: "Yuzu Lemonade",
+          price: 4,
+          description: "Sparkling lemonade with yuzu peel syrup",
+        },
+      ],
+    },
+  ],
+};
+
+export default pokelab;

--- a/src/app/data/restaurants/preps.ts
+++ b/src/app/data/restaurants/preps.ts
@@ -1,0 +1,92 @@
+import { RestaurantMenu } from "../../types/menu";
+
+const preps: RestaurantMenu = {
+  id: "preps",
+  name: "Preps",
+  cuisine: "Meal-prep comforts",
+  tagline: "Chef-made weekly menus that reheat beautifully",
+  ingredients: [
+    { name: "Roasted root vegetables", notes: "Seasonally rotating mix" },
+    { name: "Herb roasted chicken thighs", notes: "Bone-in for maximum flavor" },
+    { name: "Smoky tomato sofrito", notes: "Base for several house stews" },
+    { name: "Overnight oats blend", notes: "Chia, flax, and rolled oats" },
+  ],
+  recipes: [
+    {
+      name: "Sunday Ragu",
+      description: "Slow braised beef and tomatoes for freezer-friendly portions.",
+      ingredients: ["beef chuck", "sofrito", "crushed tomatoes", "bay leaf", "parmesan rind"],
+      steps: [
+        "Brown beef chunks, then simmer in sofrito and tomatoes for 4 hours.",
+        "Finish with parmesan rind and herbs; portion into containers.",
+      ],
+    },
+    {
+      name: "Oven-Baked Oats",
+      description: "Protein-packed breakfast squares for the week.",
+      ingredients: ["rolled oats", "chia", "almond butter", "maple", "berries"],
+      steps: [
+        "Whisk wet ingredients, fold into oat blend with berries.",
+        "Bake until set, cool completely, and slice into portions.",
+      ],
+    },
+  ],
+  menuCourses: [
+    {
+      title: "Weekly Classics",
+      description: "Heat-and-eat entrées with balanced macros",
+      items: [
+        {
+          name: "Herb Roast Chicken Pack",
+          price: 14,
+          description: "Marinated thighs, garlic green beans, lemon couscous",
+        },
+        {
+          name: "Beef Ragu Pasta",
+          price: 15,
+          description: "Slow-braised beef, parmesan, rigatoni, wilted kale",
+        },
+        {
+          name: "Smoky Chickpea Stew",
+          price: 12,
+          description: "Tomato sofrito, roasted peppers, brown rice",
+          tags: ["vegan"],
+        },
+      ],
+    },
+    {
+      title: "Light & Fresh",
+      description: "Low-carb and veggie-forward options",
+      items: [
+        {
+          name: "Lemon Dill Salmon",
+          price: 16,
+          description: "Roasted salmon, cauliflower mash, asparagus tips",
+        },
+        {
+          name: "Mediterranean Bowl",
+          price: 13,
+          description: "Za’atar chicken, roasted eggplant, pickled onions, tahini drizzle",
+        },
+      ],
+    },
+    {
+      title: "Breakfast & Snacks",
+      description: "Grab-and-go fuel for busy weeks",
+      items: [
+        {
+          name: "Berry Baked Oats",
+          price: 7,
+          description: "Almond butter, chia, maple, seasonal berries",
+        },
+        {
+          name: "Protein Egg Bites",
+          price: 6,
+          description: "Cage-free eggs, spinach, feta, roasted peppers",
+        },
+      ],
+    },
+  ],
+};
+
+export default preps;

--- a/src/app/data/restaurants/superbros.ts
+++ b/src/app/data/restaurants/superbros.ts
@@ -1,0 +1,102 @@
+import { RestaurantMenu } from "../../types/menu";
+
+const superbros: RestaurantMenu = {
+  id: "superbros",
+  name: "Superbros",
+  cuisine: "Roman-style pizza & Italian comfort",
+  tagline: "Long-fermented dough, big flavor, and bold slices",
+  ingredients: [
+    { name: "00 flour", source: "Milled in Lazio", notes: "Used for airy, crispy crust" },
+    { name: "San Marzano tomatoes", source: "Campania", notes: "Base for our signature sauce" },
+    { name: "Buffalo mozzarella", source: "Campania DOP", notes: "Creamy finish on every pie" },
+    { name: "Calabrian chili oil", notes: "House-infused for a gentle kick" },
+  ],
+  recipes: [
+    {
+      name: "Grandma Slice",
+      description: "Crispy-edge pan pizza with a slow-simmered tomato base.",
+      ingredients: ["00 flour dough", "olive oil", "garlic confit", "tomato passata", "pecorino"],
+      steps: [
+        "Sheet long-fermented dough into an oiled pan and proof.",
+        "Layer garlic confit, tomato passata, and pecorino.",
+        "Bake until the edges caramelize; finish with basil and chili oil.",
+      ],
+    },
+    {
+      name: "Truffle Funghi",
+      description: "Earthy mushrooms tossed in truffle butter over blistered dough.",
+      ingredients: ["button & oyster mushrooms", "truffle butter", "fontina", "thyme"],
+      steps: [
+        "Sauté mushrooms with thyme and sea salt.",
+        "Stretch dough, top with fontina and mushroom mix.",
+        "Bake on stone and brush crust with truffle butter.",
+      ],
+    },
+  ],
+  menuCourses: [
+    {
+      title: "Antipasti",
+      description: "Small plates to share before the slices arrive",
+      items: [
+        {
+          name: "Burrata & Roasted Peppers",
+          price: 11,
+          description: "Creamy burrata, agrodolce peppers, sourdough crisps",
+          tags: ["vegetarian"],
+        },
+        {
+          name: "Fennel Sausage Meatballs",
+          price: 10,
+          description: "Tomato sugo, pecorino romano, grilled focaccia",
+        },
+      ],
+    },
+    {
+      title: "Pizze Classiche",
+      description: "Roman-style pies with crisp bottoms and airy cornicione",
+      items: [
+        {
+          name: "Margherita DOC",
+          price: 14,
+          description: "San Marzano sauce, buffalo mozzarella, basil, first-press olive oil",
+          tags: ["signature"],
+        },
+        {
+          name: "Spicy Soppressata",
+          price: 16,
+          description: "Smoked provola, soppressata piccante, Calabrian chili honey",
+        },
+        {
+          name: "Funghi Tartufo",
+          price: 17,
+          description: "Roasted mushrooms, taleggio, white truffle cream, parsley",
+          tags: ["vegetarian"],
+        },
+      ],
+    },
+    {
+      title: "Pasta & Plates",
+      description: "House-made pastas and hearty mains",
+      items: [
+        {
+          name: "Rigatoni alla Vodka",
+          price: 15,
+          description: "Creamy tomato vodka sauce, guanciale crumbs, pecorino",
+        },
+        {
+          name: "Cacio e Pepe",
+          price: 14,
+          description: "Bronze-cut tonnarelli tossed with pecorino and cracked pepper",
+          tags: ["vegetarian"],
+        },
+        {
+          name: "Fire-Roasted Sea Bass",
+          price: 22,
+          description: "Charred lemon, salsa verde, wilted chicory",
+        },
+      ],
+    },
+  ],
+};
+
+export default superbros;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,11 @@
 
 import { useRouter } from "next/navigation";
 import { Button } from "./components/Button";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { signIn } from "next-auth/react";
 import { ChevronDown, ChevronUp } from "lucide-react";
+import { restaurantMenuList, restaurantMenus } from "./data/restaurants";
+import { RestaurantMenu } from "./types/menu";
 
 type RegisterForm = {
   userType?: "influencer" | "restaurant";
@@ -46,6 +48,12 @@ export default function Home() {
   const [restaurantDiscounts, setRestaurantDiscounts] = useState<any[]>([]);
   const [isLoadingDiscounts, setIsLoadingDiscounts] = useState(false);
   const [collapsedDiscountIndexes, setCollapsedDiscountIndexes] = useState<number[]>([]);
+  const [activeMenuId, setActiveMenuId] = useState<string>(restaurantMenuList[0]?.id ?? "");
+
+  const activeMenu: RestaurantMenu | undefined = useMemo(
+    () => restaurantMenus[activeMenuId] ?? restaurantMenuList[0],
+    [activeMenuId]
+  );
 
   const hasRequiredFields = () => {
     if (!registerForm.userType) {
@@ -510,14 +518,136 @@ export default function Home() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-emerald-50 to-white flex flex-col items-center justify-center px-4">
-      <div className="max-w-xl text-center">
-        <h1 className="text-4xl md:text-5xl font-extrabold text-emerald-800 mb-6">
-          Become a Food Influencer & Earn Discounts
-        </h1>
-        <p className="text-lg md:text-xl text-emerald-700 mb-10">
-          You can be our influencer! Post your food, show your results, and get rewarded with discounts at your favorite restaurants.
-        </p>
-        <div className="flex flex-col sm:flex-row gap-4 justify-center mb-6">
+      <div className="w-full max-w-5xl">
+        <div className="max-w-2xl text-center mx-auto">
+          <h1 className="text-4xl md:text-5xl font-extrabold text-emerald-800 mb-6">
+            Become a Food Influencer & Earn Discounts
+          </h1>
+          <p className="text-lg md:text-xl text-emerald-700 mb-10">
+            You can be our influencer! Post your food, show your results, and get rewarded with discounts at your favorite restaurants.
+          </p>
+        </div>
+        <section className="w-full bg-white/80 backdrop-blur rounded-3xl shadow-lg border border-emerald-100 p-5 text-left mb-8">
+          <div className="flex flex-col gap-6">
+            <div>
+              <p className="text-xs font-semibold text-emerald-600 uppercase tracking-widest">Menus</p>
+              <h2 className="text-2xl font-bold text-emerald-800">{activeMenu?.name ?? "Restaurant menu"}</h2>
+              <p className="text-sm text-emerald-700">
+                {activeMenu?.tagline || activeMenu?.cuisine || "Choose a restaurant to explore its menu."}
+              </p>
+            </div>
+
+            <div className="grid md:grid-cols-5 gap-4">
+              <div className="md:col-span-2 space-y-3">
+                <p className="text-sm font-semibold text-emerald-700">Select a restaurant</p>
+                <div className="grid grid-cols-1 gap-3">
+                  {restaurantMenuList.map((menu) => {
+                    const isActive = menu.id === activeMenuId;
+                    return (
+                      <button
+                        key={menu.id}
+                        type="button"
+                        onClick={() => setActiveMenuId(menu.id)}
+                        className={`text-left rounded-2xl border p-3 transition shadow-sm ${
+                          isActive
+                            ? "bg-emerald-700 text-white border-emerald-700"
+                            : "bg-white text-emerald-800 border-emerald-200 hover:border-emerald-400"
+                        }`}
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="font-semibold">{menu.name}</span>
+                          {isActive && <span className="text-xs px-2 py-1 rounded-full bg-white/20">Active</span>}
+                        </div>
+                        <p className={`text-sm ${isActive ? "text-emerald-50" : "text-emerald-700"}`}>
+                          {menu.cuisine}
+                        </p>
+                        {menu.tagline && (
+                          <p className={`text-xs mt-1 ${isActive ? "text-emerald-100" : "text-emerald-600"}`}>
+                            {menu.tagline}
+                          </p>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="md:col-span-3 space-y-4">
+                <div className="rounded-2xl bg-gradient-to-br from-emerald-900 to-emerald-700 text-white p-4 shadow-lg border border-emerald-800">
+                  <p className="text-xs uppercase tracking-widest text-emerald-100">Menu Courses</p>
+                  <h3 className="text-xl font-bold mt-1">{activeMenu?.name ?? "Menu"}</h3>
+                  <p className="text-sm text-emerald-100">{activeMenu?.cuisine}</p>
+
+                  <div className="mt-4 space-y-4">
+                    {activeMenu?.menuCourses.map((course) => (
+                      <div key={course.title} className="rounded-xl bg-white/10 p-3">
+                        <div className="flex items-start justify-between gap-4">
+                          <div>
+                            <p className="text-sm uppercase tracking-wide text-emerald-100">{course.title}</p>
+                            {course.description && <p className="text-xs text-emerald-50">{course.description}</p>}
+                          </div>
+                        </div>
+                        <ul className="mt-2 space-y-2">
+                          {course.items.map((item) => (
+                            <li key={`${course.title}-${item.name}`} className="flex items-start justify-between gap-3">
+                              <div>
+                                <p className="font-semibold">{item.name}</p>
+                                <p className="text-xs text-emerald-50">{item.description}</p>
+                                {item.tags && (
+                                  <div className="flex flex-wrap gap-1 mt-1">
+                                    {item.tags.map((tag) => (
+                                      <span
+                                        key={tag}
+                                        className="text-[10px] px-2 py-0.5 rounded-full bg-white/20 text-white"
+                                      >
+                                        {tag}
+                                      </span>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                              <span className="text-sm font-semibold">€{item.price}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-4 grid sm:grid-cols-2 gap-3 text-emerald-50">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-emerald-100">Pantry Highlights</p>
+                      <ul className="mt-1 space-y-1 text-xs">
+                        {activeMenu?.ingredients.slice(0, 4).map((ingredient) => (
+                          <li key={ingredient.name} className="flex items-start gap-2">
+                            <span className="mt-[2px] h-2 w-2 rounded-full bg-emerald-200" aria-hidden />
+                            <span>
+                              <span className="font-semibold">{ingredient.name}</span>
+                              {ingredient.source && ` • ${ingredient.source}`}
+                              {ingredient.notes && <span className="text-emerald-100"> — {ingredient.notes}</span>}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-emerald-100">Signature Recipes</p>
+                      <ul className="mt-1 space-y-1 text-xs">
+                        {activeMenu?.recipes.slice(0, 2).map((recipe) => (
+                          <li key={recipe.name}>
+                            <span className="font-semibold">{recipe.name}:</span> {recipe.description}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+        <div className="max-w-xl text-center mx-auto">
+          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-6">
           <Button
             onClick={() => {
               setActiveTab("login");
@@ -1033,6 +1163,7 @@ export default function Home() {
             )}
           </div>
         )}
+        </div>
       </div>
     </main>
   );

--- a/src/app/types/menu.ts
+++ b/src/app/types/menu.ts
@@ -1,0 +1,35 @@
+export type Ingredient = {
+  name: string;
+  source?: string;
+  notes?: string;
+};
+
+export type Recipe = {
+  name: string;
+  description: string;
+  ingredients: string[];
+  steps: string[];
+};
+
+export type MenuItem = {
+  name: string;
+  price: number;
+  description: string;
+  tags?: string[];
+};
+
+export type MenuCourse = {
+  title: string;
+  description?: string;
+  items: MenuItem[];
+};
+
+export type RestaurantMenu = {
+  id: string;
+  name: string;
+  cuisine: string;
+  tagline?: string;
+  ingredients: Ingredient[];
+  recipes: Recipe[];
+  menuCourses: MenuCourse[];
+};


### PR DESCRIPTION
## Summary
- add dedicated menu data for each restaurant including ingredients, recipes, and courses
- expose a shared registry of restaurant menus for lookup
- update the home page to display the selected restaurant’s menu and branding

## Testing
- npm install *(fails: 403 Forbidden fetching picomatch)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921cdbd4d2c832596fa5cb42b3d2d8f)